### PR TITLE
1.1 thaize

### DIFF
--- a/scripts/feature_selection.py
+++ b/scripts/feature_selection.py
@@ -1,0 +1,44 @@
+from data_loader import get_data
+import numpy as np
+from sklearn.preprocessing import OrdinalEncoder
+from sklearn.feature_selection import VarianceThreshold
+
+def ordinal_encoding(df): 
+    """Encode categorical feats using OrdinalEncoder
+    Args:
+        df (DataFrame): Dataframe object
+    Returns:
+        dataframe (DataFrame): output dataframe
+    @Author: Nicolas THAIZE
+    """
+    encoded_df = df.copy()
+    ord_enc = OrdinalEncoder()
+    categorical_features = encoded_df.select_dtypes('object').columns
+    encoded_df[categorical_features] = ord_enc.fit_transform(encoded_df[categorical_features])
+    return encoded_df
+
+def drop_low_var_feats(df, auto_ordinal_encode = True, threshold = 0.1):
+    """Drop features that have > (1 - threshold %) simmilar values
+    Args:
+        df (DataFrame): Dataframe object
+        auto_ordinal_encode (boolean): If true, encode categorical features
+            By default True
+        threshold (float): variance threshold to drop features
+    Returns:
+        dataframe (DataFrame): output dataframe
+    
+    @Author: Nicolas THAIZE
+    """
+    temp_df = df.copy()
+    if auto_ordinal_encode:
+        temp_df = ordinal_encoding(temp_df)
+    var_thr = VarianceThreshold(threshold = threshold)
+    var_thr.fit(temp_df)
+    var_thr.get_support()
+    low_var_feats = [column for column in temp_df.columns if column not in temp_df.columns[var_thr.get_support()]]
+    return df.drop(low_var_feats,axis=1)
+
+if __name__ == "__main__":
+    df = get_data(file_path = "./data/en.openfoodfacts.org.products.csv", nrows=50)
+    feature_selected_df = drop_low_var_feats(df)
+    

--- a/scripts/feature_selection.py
+++ b/scripts/feature_selection.py
@@ -1,44 +1,79 @@
 from data_loader import get_data
-import numpy as np
 from sklearn.preprocessing import OrdinalEncoder
 from sklearn.feature_selection import VarianceThreshold
+import unittest
 
-def ordinal_encoding(df): 
-    """Encode categorical feats using OrdinalEncoder
-    Args:
-        df (DataFrame): Dataframe object
-    Returns:
-        dataframe (DataFrame): output dataframe
-    @Author: Nicolas THAIZE
-    """
-    encoded_df = df.copy()
-    ord_enc = OrdinalEncoder()
-    categorical_features = encoded_df.select_dtypes('object').columns
-    encoded_df[categorical_features] = ord_enc.fit_transform(encoded_df[categorical_features])
-    return encoded_df
+class FeatureSelection:
+    def __init__(self, df):
+        self.df = df
 
-def drop_low_var_feats(df, auto_ordinal_encode = True, threshold = 0.1):
-    """Drop features that have > (1 - threshold %) simmilar values
-    Args:
-        df (DataFrame): Dataframe object
-        auto_ordinal_encode (boolean): If true, encode categorical features
-            By default True
-        threshold (float): variance threshold to drop features
-    Returns:
-        dataframe (DataFrame): output dataframe
-    
-    @Author: Nicolas THAIZE
-    """
-    temp_df = df.copy()
-    if auto_ordinal_encode:
-        temp_df = ordinal_encoding(temp_df)
-    var_thr = VarianceThreshold(threshold = threshold)
-    var_thr.fit(temp_df)
-    var_thr.get_support()
-    low_var_feats = [column for column in temp_df.columns if column not in temp_df.columns[var_thr.get_support()]]
-    return df.drop(low_var_feats,axis=1)
+    def set_df(self, df):
+        self.df = df
+
+    def ordinal_encoding(self, df): 
+        """Encode categorical feats using OrdinalEncoder
+        Args:
+            df (DataFrame): Dataframe object
+        Returns:
+            dataframe (DataFrame): output dataframe
+        @Author: Nicolas THAIZE
+        """
+        encoded_df = df.copy()
+        ord_enc = OrdinalEncoder()
+        categorical_features = encoded_df.select_dtypes('object').columns
+        encoded_df[categorical_features] = ord_enc.fit_transform(encoded_df[categorical_features])
+        return encoded_df
+
+    def drop_low_var_feats(self, auto_ordinal_encode = True, threshold = 0.1):
+        """Drop features that have > (1 - threshold %) simmilar values
+        Args:
+            df (DataFrame): Dataframe object
+            auto_ordinal_encode (boolean): If true, encode categorical features
+                By default True
+            threshold (float): variance threshold to drop features
+        Returns:
+            dataframe (DataFrame): output dataframe
+        
+        @Author: Nicolas THAIZE
+        """
+        temp_df = self.df.copy()
+        if auto_ordinal_encode:
+            temp_df = self.ordinal_encoding(temp_df)
+        var_thr = VarianceThreshold(threshold = threshold)
+        var_thr.fit(temp_df)
+        var_thr.get_support()
+        low_var_feats = [column for column in temp_df.columns if column not in temp_df.columns[var_thr.get_support()]]
+        return self.df.drop(low_var_feats,axis=1)
 
 if __name__ == "__main__":
-    df = get_data(file_path = "./data/en.openfoodfacts.org.products.csv", nrows=50)
-    feature_selected_df = drop_low_var_feats(df)
+
+    # Unit testing FeatureSelection class
+    class TestFeatureSelection(unittest.TestCase):
+        def test_shape(self):
+            df = get_data(file_path = "./data/en.openfoodfacts.org.products.csv", nrows=50)
+            feature_selection = FeatureSelection(df)
+            features_selected = feature_selection.drop_low_var_feats()
+            self.assertNotEqual(df.shape, features_selected.shape, "Shapes are not same size")
+
+        def test_cols(self):
+            def isSubset(arr1, arr2):
+                m=len(arr1)
+                n=len(arr2)
+                st = set()
+                for i in range(0, m):
+                    st.add(arr1[i])
+                for i in range(0, n):
+                    if arr2[i] in st:
+                        continue
+                    else:
+                        return False
+                return True
+
+            df = get_data(file_path = "./data/en.openfoodfacts.org.products.csv", nrows=50)
+            feature_selection = FeatureSelection(df)
+            features_selected = feature_selection.drop_low_var_feats()
+            assert_val = isSubset(df.columns.to_list(), features_selected.columns.to_list())
+
+            self.assertTrue(assert_val, "Cols are not included")
     
+    unittest.main()


### PR DESCRIPTION
J'ai implémenté un variance threshold que l'on peut simplement paramétrer qui nous renvoie automatiquement le dataset "trié". De plus étant donné que l'on ne peux pas travailler sur un dataset ayant des données manquantes j'ai, naïvement, proposé d'auto encoder les données.

J'ai uniquement poussé cette fonctionnalité car j'ai tenté des analyses en utilisant le Laplacian Score mais le coût computationnel est BIEN trop important pour que ce soit réalisable [WhitePaper](https://proceedings.neurips.cc/paper_files/paper/2005/file/b5b03f06271f8917685d14cea7c6c50a-Paper.pdf).

Je n'ai pas non plus réalisé de PCA étant donné qu'une tâche lui est dédiée.